### PR TITLE
Fix browser handling in scraper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord.py>=2.0
 aiohttp
+playwright


### PR DESCRIPTION
## Summary
- reuse a single Playwright browser instance instead of launching a new one every loop
- add `playwright` to requirements

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68531fec1ee483328e407b8477e3d94d