### PR TITLE
Handle direct image responses from Imgur

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This bot attempts to discover public images hosted on [imgBB](https://imgbb.com)
 
 ## Configuration
 
-Copy `config.example.json` to `config.json` and fill in your Discord bot token and the channel ID you want to post found images to. Add one or more target URLs with their associated code length under `urls`.
+Copy `config.example.json` to `config.json` and fill in your Discord bot token and the channel ID you want to post found images to. Add one or more target URLs with their associated code length under `urls`. Optional settings such as `rate_limit` and `user_agent` can be supplied per URL.
 
 ```
 {

--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,10 @@
   "token": "YOUR_DISCORD_BOT_TOKEN",
   "channel_id": 123456789012345678,
   "urls": {
-    "https://ibb.co": 8
+    "https://ibb.co": {
+      "length": 8,
+      "rate_limit": 1.0,
+      "user_agent": "Mozilla/5.0 (compatible; DiscordBot/1.0)"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- handle Imgur pages that serve images directly
- respect per-URL user agent in config

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_685327f4415c8332aa28f358459d9581