### PR TITLE
Add prnt.sc scraper from Screenshot Stealer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Install the requirements and run `bot.py`:
 
 ```
 pip install -r requirements.txt
+playwright install
 python bot.py
 ```
 


### PR DESCRIPTION
## Summary
- integrate helpers from Screenshot Stealer project
- add specialized scraper for `prnt.sc`
- document Playwright install step

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python bot.py` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6855efcee6cc83329b035350c68d66a8