### PR TITLE
Handle network hangs with timeouts

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -117,12 +117,16 @@ def save_distributions() -> None:
         "valid": {d: {str(k): [dict(c) for c in v] for k, v in lv.items()} for d, lv in code_distributions.items()},
         "invalid": {d: {str(k): [dict(c) for c in v] for k, v in lv.items()} for d, lv in invalid_distributions.items()},
     }
+    logger.info("Saving statistics to %s", STATS_FILE)
     with open(STATS_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
+    logger.info("Saved statistics to %s", STATS_FILE)
 
 def load_distributions() -> None:
     if not os.path.exists(STATS_FILE):
+        logger.info("Statistics file %s does not exist", STATS_FILE)
         return
+    logger.info("Loading statistics from %s", STATS_FILE)
     with open(STATS_FILE, "r", encoding="utf-8") as f:
         data = json.load(f)
 
@@ -144,7 +148,7 @@ def load_distributions() -> None:
 
 async def fetch_image(session: aiohttp.ClientSession, url: str, headers=None) -> bytes | None:
     try:
-        async with session.get(url, headers=headers) as resp:
+        async with session.get(url, headers=headers, timeout=10) as resp:
             status = resp.status
             content_type = resp.headers.get("Content-Type", "")
             if status == 200 and content_type.startswith("image"):
@@ -418,7 +422,10 @@ async def scrape_loop():
                                         file = discord.File(io.BytesIO(image_data), filename="image.png")
                                         embed = discord.Embed(url=url)
                                         embed.set_image(url="attachment://image.png")
-                                        await channel.send(url, embed=embed, file=file)
+                                        await asyncio.wait_for(
+                                            channel.send(url, embed=embed, file=file),
+                                            timeout=10,
+                                        )
                                     except Exception as e:
                                         logger.error("Failed to send message to Discord: %s", e)
                                 break
@@ -436,14 +443,14 @@ async def scrape_loop():
         finally:
             if browser:
                 try:
-                    await browser.close()
+                    await asyncio.wait_for(browser.close(), timeout=10)
                     logger.info("Browser closed")
                 except Exception as exc:
                     logger.warning("Failed to close browser: %s", exc)
                 browser = None
             if p:
                 try:
-                    await p.stop()
+                    await asyncio.wait_for(p.stop(), timeout=10)
                     logger.info("Playwright stopped")
                 except Exception as exc:
                     logger.warning("Failed to stop Playwright: %s", exc)


### PR DESCRIPTION
## Summary
- set a 10 second timeout when sending images to Discord
- log whenever loading or saving stats files

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6857780b589c8332a9b81f550d155478