### PR TITLE
Fix indentation error in check_youtube_video

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -328,7 +328,6 @@ async def check_youtube_video(
     headers=None,
 ) -> bool:
 
- main
     try:
         async with session.get(url, headers=headers, timeout=10) as resp:
             if resp.status == 200:


### PR DESCRIPTION
## Summary
- remove stray `main` line causing indentation error

## Testing
- `python3 -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68598a91e11c8332ab9c9b53e2112e10