### PR TITLE
Extend supported domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ The bot has a built-in list of supported services so no additional configuration
 | cl.ly | 6 |
 | prnt.sc | 6 |
 | youtu.be | 11 (checked via `https://www.youtube.com/watch?v=CODE`) |
+| vgy.me | 5 |
+| catbox.moe | 6 |
+| tinyurl.com | 6 |
+| is.gd | 6 |
+| bit.ly | 7 |
+| pastebin.com | 8 |
+| gist.github.com | 32 |
 
 
 ```


### PR DESCRIPTION
## Summary
- add more domains to the built-in configuration
- adjust heuristics for new services
- look up images from these domains in the scraper
- document the new supported services
- add support for GitHub Gist and Pastebin

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6859921dff6c8332894f03e70ec00395