### PR TITLE
Add domain stats persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The bot will log attempts and post any discovered images to the configured Disco
 
 Character frequency statistics are saved to `char_stats.json` and used to bias code generation toward more common letters for each domain.
 
+Each domain also maintains a simple weight that influences how often it is selected for testing. Domains start with a weight of `1.0` and the value is adjusted based on whether links are found to be valid or invalid during scraping. The current weights are stored in `domain_stats.json` so the bot can learn over time which services are more reliable.
+
 ### Imgur support
 
 Imgur pages and direct `i.imgur.com` links are handled automatically without any additional configuration. Both the page URL and direct image links such as `https://i.imgur.com/rMluBf1_d.webp` will be processed.


### PR DESCRIPTION
## Summary
- persist domain weights between runs
- track and load domain weights from `domain_stats.json`
- document the new file

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6859be63bd988332afa81af314ffc051