### PR TITLE
Handle missing stats json

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Character frequency statistics are saved to `char_stats.json` and used to bias c
 
 Each domain also maintains a simple weight that influences how often it is selected for testing. Domains start with a weight of `1.0` and the value is adjusted based on whether links are found to be valid or invalid during scraping. The current weights are stored in `domain_stats.json` so the bot can learn over time which services are more reliable.
 
+If either of these files is missing or contains invalid JSON, the bot will reset
+them to default empty structures on startup.
+
 ### Imgur support
 
 Imgur pages and direct `i.imgur.com` links are handled automatically without any additional configuration. Both the page URL and direct image links such as `https://i.imgur.com/rMluBf1_d.webp` will be processed.

--- a/bot.py
+++ b/bot.py
@@ -183,11 +183,17 @@ def save_domain_stats() -> None:
 
 def load_distributions() -> None:
     if not os.path.exists(STATS_FILE):
-        logger.info("Statistics file %s does not exist", STATS_FILE)
+        logger.info("Statistics file %s does not exist, creating defaults", STATS_FILE)
+        save_distributions()
         return
     logger.info("Loading statistics from %s", STATS_FILE)
-    with open(STATS_FILE, "r", encoding="utf-8") as f:
-        data = json.load(f)
+    try:
+        with open(STATS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError:
+        logger.warning("Statistics file %s is invalid, resetting", STATS_FILE)
+        save_distributions()
+        return
 
     for domain, lengths in data.get("valid", {}).items():
         for length_str, counters in lengths.items():
@@ -208,11 +214,20 @@ def load_distributions() -> None:
 def load_domain_stats() -> None:
     """Load domain weights from DOMAIN_STATS_FILE if it exists."""
     if not os.path.exists(DOMAIN_STATS_FILE):
-        logger.info("Domain weights file %s does not exist", DOMAIN_STATS_FILE)
+        logger.info(
+            "Domain weights file %s does not exist, creating defaults",
+            DOMAIN_STATS_FILE,
+        )
+        save_domain_stats()
         return
     logger.info("Loading domain weights from %s", DOMAIN_STATS_FILE)
-    with open(DOMAIN_STATS_FILE, "r", encoding="utf-8") as f:
-        data = json.load(f)
+    try:
+        with open(DOMAIN_STATS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError:
+        logger.warning("Domain weights file %s is invalid, resetting", DOMAIN_STATS_FILE)
+        save_domain_stats()
+        return
     for domain, weight in data.items():
         if domain in DOMAIN_WEIGHTS:
             DOMAIN_WEIGHTS[domain] = float(weight)


### PR DESCRIPTION
## Summary
- handle invalid or missing `char_stats.json` and `domain_stats.json`
- document that missing stats files are recreated automatically

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6859c4c4dda08332b2b505ce1fd59b3f