### PR TITLE
Adjust domain weight decay

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ python bot.py
 
 The bot will log attempts and post any discovered images to the configured Discord channel.
 
-Character frequency statistics are saved to `char_stats.json` and used to bias code generation toward more common letters for each domain.
+Character frequency statistics are saved to `char_stats.json` and used to bias code generation toward more common letters for each domain. The file is loaded when the bot starts and written back regularly alongside the domain weights so learning persists between runs.
 
-Each domain also maintains a simple weight that influences how often it is selected for testing. Domains start with a weight of `1.0` and the value is adjusted based on whether links are found to be valid or invalid during scraping. The current weights are stored in `domain_stats.json` so the bot can learn over time which services are more reliable.
+Each domain also maintains a simple weight that influences how often it is selected for testing. Domains start at `1.0` and increase by `0.1` whenever a link is valid. Invalid links decrease the weight by `0.025`, but a domain's weight will never drop below `1.0`. The current weights are stored in `domain_stats.json` so the bot can learn over time which services are more reliable.
 
 If either of these files is missing or contains invalid JSON, the bot will reset
 them to default empty structures on startup.

--- a/bot.py
+++ b/bot.py
@@ -57,7 +57,7 @@ DOMAINS = {
 # These values are adjusted at runtime based on valid/invalid results.
 DOMAIN_WEIGHTS = {domain: cfg.get("weight", 1.0) for domain, cfg in DOMAINS.items()}
 WEIGHT_INCREASE = 0.1
-WEIGHT_DECREASE = 0.1
+WEIGHT_DECREASE = 0.025
 
 # Domains that host text rather than images. For these we simply verify that a
 # page exists and send the link without attempting to embed an image.
@@ -155,7 +155,7 @@ def update_domain_weight(domain: str, valid: bool) -> None:
     if valid:
         DOMAIN_WEIGHTS[domain] += WEIGHT_INCREASE
     else:
-        DOMAIN_WEIGHTS[domain] = max(0.1, DOMAIN_WEIGHTS[domain] - WEIGHT_DECREASE)
+        DOMAIN_WEIGHTS[domain] = max(1.0, DOMAIN_WEIGHTS[domain] - WEIGHT_DECREASE)
 
 
 def choose_domain() -> str:
@@ -256,7 +256,7 @@ def load_domain_stats() -> None:
         return
     for domain, weight in data.items():
         if domain in DOMAIN_WEIGHTS:
-            DOMAIN_WEIGHTS[domain] = float(weight)
+            DOMAIN_WEIGHTS[domain] = max(1.0, float(weight))
 
 async def fetch_image(session: aiohttp.ClientSession, url: str, headers=None) -> bytes | None:
     try:
@@ -611,6 +611,7 @@ async def scrape_loop():
                                 "Heartbeat: processed %d URLs", scrape_count
                             )
                             save_distributions()
+                            load_distributions()
                             save_domain_stats()
                             load_domain_stats()
                         elif scrape_count % SAVE_STATS_EVERY == 0:
@@ -618,6 +619,7 @@ async def scrape_loop():
                                 "Heartbeat: processed %d URLs", scrape_count
                             )
                             save_distributions()
+                            load_distributions()
 
                         if domain == "youtu.be":
                             if not result:


### PR DESCRIPTION
## Summary
- tune weight adjustments so failures hurt less than successes help
- clarify the weighting behaviour in README
- reload `char_stats.json` whenever domain weights are saved

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859d0bd1cfc833283c6a97e7bb0e964