### PR TITLE
Fix detection of deleted Reddit users

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ This bot attempts to discover public images hosted on [imgBB](https://imgbb.com)
 
 ## Configuration
 
-Copy `config.example.json` to `config.json` and fill in your Discord bot token,
-the channel ID you want to post found images to, and the subreddit you want to
-probe.
+Copy `config.example.json` to `config.json` and fill in your Discord bot token
+and the channel ID you want to post found images to.
 
 The bot has a built-in list of supported services so no additional configuration is required.
 
@@ -27,14 +26,14 @@ The bot has a built-in list of supported services so no additional configuration
 | bit.ly | 7 |
 | rb.gy | 6 |
 | pastebin.com | 8 |
-| reddit.com | 6 |
+| reddit.com | 6 (posts parsed for media link) |
 
+Reddit posts are treated like redirects to the linked image or video.
 
 ```
 {
   "token": "YOUR_DISCORD_BOT_TOKEN",
-  "channel_id": 123456789012345678,
-  "reddit_subreddit": "foo"
+  "channel_id": 123456789012345678
 }
 ```
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,4 @@
 {
   "token": "YOUR_DISCORD_BOT_TOKEN",
-  "channel_id": 123456789012345678,
-  "reddit_subreddit": "foo"
+  "channel_id": 123456789012345678
 }


### PR DESCRIPTION
## Summary
- detect `faceplate-tracker` element with `[deleted]`
- ignore crossposts that link to self posts
- restrict Reddit results to media posts only
- use `https://reddit.com/comments` by default
- remove subreddit config option
- parse Reddit posts for the linked media URL and treat them as redirects

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_685b0525d96c83329dfa9e3c8f15e6ef