### PR TITLE
Fix Reddit embed duplication

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -863,13 +863,18 @@ async def scrape_loop():
                                         embed = discord.Embed(url=final_url)
                                         embed.set_image(url="attachment://screenshot.png")
                                         content = f"{url} -> {final_url}"
+                                        if domain in SHORTENER_DOMAINS:
+                                            content = f"`{url}` -> {final_url}"
                                         await asyncio.wait_for(
                                             channel.send(content, embed=embed, file=file),
                                             timeout=10,
                                         )
                                     else:
+                                        content = f"{url} -> {final_url}"
+                                        if domain in SHORTENER_DOMAINS:
+                                            content = f"`{url}` -> {final_url}"
                                         await asyncio.wait_for(
-                                            channel.send(f"{url} -> {final_url}"),
+                                            channel.send(content),
                                             timeout=10,
                                         )
                                 except Exception as e:


### PR DESCRIPTION
## Summary
- show only the final URL embed for redirect and shortener links by wrapping the original link in backticks

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_685b0c9aa7fc83329af79aefb7564a32