### PR TITLE
Fix GoToMeeting url and Discord validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The bot has a built-in list of supported services so no additional configuration
 | bit.ly | 7 |
 | rb.gy | 6 |
 | zoom.us | 9 or 11 digits |
-| app.gotomeet.me | 9 digits |
+| app.goto.com/meeting | 9 digits |
 | webex.com | 9–11 digits |
 | meet.chime.in | 10 digits |
 | discord.gg | 7–10 characters |


### PR DESCRIPTION
## Summary
- point GoToMeeting links to `app.goto.com/meeting`
- improve Discord invite detection by waiting for page load and checking for valid text

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685f1e947e988332a4f1d4457a233f5e