### PR TITLE
Add configurable scrape workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Reddit posts are treated like redirects to the linked image or video.
 ```
 {
   "token": "YOUR_DISCORD_BOT_TOKEN",
-  "channel_id": 123456789012345678
+  "channel_id": 123456789012345678,
+  "scrape_workers": 4
 }
 ```
 
@@ -52,9 +53,10 @@ them to default empty structures on startup.
 
 ### Concurrency
 
-The scraper can run multiple workers in parallel to speed up scanning. Set the
-`SCRAPE_WORKERS` environment variable to the desired number of concurrent
-workers:
+The scraper can run multiple workers in parallel to speed up scanning. The
+number of workers can be configured in `config.json` using the `scrape_workers`
+field (defaults to `4`). You can also override this at runtime with the
+`SCRAPE_WORKERS` environment variable:
 
 ```
 SCRAPE_WORKERS=4 python bot.py

--- a/bot.py
+++ b/bot.py
@@ -110,9 +110,10 @@ client = discord.Client(intents=intents)
 
 scrape_tasks: list[asyncio.Task] = []
 
-# Number of concurrent scraping workers to run. This can also be overridden
-# via the SCRAPE_WORKERS environment variable.
-SCRAPE_WORKERS = int(os.environ.get("SCRAPE_WORKERS", "1"))
+# Number of concurrent scraping workers to run. This can be configured in
+# config.json using the "scrape_workers" field and overridden at runtime via the
+# SCRAPE_WORKERS environment variable.
+SCRAPE_WORKERS = int(os.environ.get("SCRAPE_WORKERS", config.get("scrape_workers", 4)))
 
 tested_urls = set()
 tested_lock = asyncio.Lock()

--- a/config.example.json
+++ b/config.example.json
@@ -1,4 +1,5 @@
 {
   "token": "YOUR_DISCORD_BOT_TOKEN",
-  "channel_id": 123456789012345678
+  "channel_id": 123456789012345678,
+  "scrape_workers": 4
 }


### PR DESCRIPTION
## Summary
- allow specifying scrape worker count in `config.json`
- document the new setting and use 4 workers by default
- keep environment variable override for one-off runs

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686ee1c7a9ec833282fab6524f36e418