### PR TITLE
Fix config path lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ This bot attempts to discover publicly accessible media by generating random sho
 ## Configuration
 
 Copy `config.example.json` to `config.json` and fill in your Discord bot token
-and the channel ID you want to post found images to.
+and the channel ID you want to post found images to. The bot looks for this
+file in the same directory as `bot.py`, so ensure it is placed there even if you
+launch the script from a different working directory.
 
 The bot has a built-in list of supported services so no additional configuration is required.
 

--- a/bot.py
+++ b/bot.py
@@ -15,10 +15,13 @@ import aiohttp
 import discord
 from playwright.async_api import async_playwright, Browser
 
-CONFIG_FILE = "config.json"
-STATS_FILE = "char_stats.json"
-DOMAIN_STATS_FILE = "domain_stats.json"
-PATTERN_STATS_FILE = "pattern_stats.json"
+# Resolve data files relative to this script's location so the bot can be run
+# from any working directory.
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_FILE = os.path.join(BASE_DIR, "config.json")
+STATS_FILE = os.path.join(BASE_DIR, "char_stats.json")
+DOMAIN_STATS_FILE = os.path.join(BASE_DIR, "domain_stats.json")
+PATTERN_STATS_FILE = os.path.join(BASE_DIR, "pattern_stats.json")
 
 if not os.path.exists(CONFIG_FILE):
     raise RuntimeError(f"Missing {CONFIG_FILE}. See config.example.json")


### PR DESCRIPTION
## Summary
- fix config loading when launching bot from a different working directory
- document the need to keep `config.json` next to `bot.py`

## Testing
- `python3 -m py_compile bot.py`
- `python3 -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687ab4b5be548332918b02f8d40d6527