### PR TITLE
Improve media handling for Reddit and Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The bot has a built-in list of supported services so no additional configuration
 | app.goto.com/meeting | 9 digits |
 | reddit.com | 6 (posts parsed for media link) |
 
-Reddit posts are treated like redirects to the linked image or video.
+Reddit posts are treated like redirects to the linked image or video and the
+media is uploaded directly when possible.
 
 ```
 {


### PR DESCRIPTION
## Summary
- upload Reddit images and videos directly
- add generic media helper and Matrix support for videos
- keep redirect links clickable in Matrix messages
- document Reddit uploads in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882b383fe7483329afe4f24e8bb2c50